### PR TITLE
Only display datasets by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
+
 python:
-    - "2.6"
-    - "2.7"
-env: PGVERSION=9.1
-install:
-    - bash bin/travis-build.bash
-    - pip install coveralls
-script: sh bin/travis-run.sh
-after_success:
-    - coveralls
+- '2.7'
+
+install: 
+    - pip install -r dev-requirements.txt
+    - pip install -r requirements.txt
+
+script: ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+function cleanup {
+    exit $?
+}
+
+trap "cleanup" EXIT
+
+# Check PEP-8 code style and McCabe complexity
+flake8 --show-pep8 --show-source ckanext
+
+# run tests
+# nosetests --verbose

--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -8,27 +8,34 @@ from ckan.common import _
 import logging
 log = logging.getLogger(__name__)
 
+
 def get_dataset_count():
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     req_context = {'user': user['name']}
 
-    packages = tk.get_action('package_search')(req_context, {'fq': '+dataset_type:dataset'})
+    packages = tk.get_action('package_search')(
+        req_context,
+        {'fq': '+dataset_type:dataset'}
+    )
     return packages['count']
+
 
 def get_group_count():
     '''
     Return the number of groups
     '''
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     req_context = {'user': user['name']}
     groups = tk.get_action('group_list')(req_context, {})
     return len(groups)
 
+
 def get_org_count():
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     req_context = {'user': user['name']}
     orgs = tk.get_action('organization_list')(req_context, {})
     return len(orgs)
+
 
 def get_app_count():
     result = _call_wp_api('app_statistics')
@@ -36,11 +43,13 @@ def get_app_count():
         return result['data']['app_count']
     return 'N/A'
 
+
 def get_tweet_count():
     result = _call_wp_api('tweet_statistics')
     if result is not None:
         return result['data']['tweet_count']
     return 'N/A'
+
 
 def _call_wp_api(action):
     api_url = pylons.config.get('ckanext.switzerland.wp_ajax_url', None)
@@ -55,32 +64,45 @@ def _call_wp_api(action):
     except:
         return None
 
+
 def get_localized_org(org_id=None, include_datasets=False):
     if not org_id or org_id is None:
         return {}
     try:
         return logic.get_action('organization_show')(
-               {'for_view': True}, {'id': org_id, 'include_datasets': include_datasets})
-    except (logic.NotFound, logic.ValidationError, logic.NotAuthorized, AttributeError):
+            {'for_view': True},
+            {'id': org_id, 'include_datasets': include_datasets}
+        )
+    except (logic.NotFound, logic.ValidationError,
+            logic.NotAuthorized, AttributeError):
         return {}
+
 
 def localize_json_title(facet_item):
     try:
         lang_dict = json.loads(facet_item['display_name'])
-        return get_localized_value(lang_dict, default_value=facet_item['display_name'])
+        return get_localized_value(
+            lang_dict,
+            default_value=facet_item['display_name']
+        )
     except:
         return facet_item['display_name']
 
+
 def get_langs():
-    language_priorities = ['en', 'de', 'fr', 'it'] 
+    language_priorities = ['en', 'de', 'fr', 'it']
     return language_priorities
+
 
 def get_localized_value(lang_dict, desired_lang_code=None, default_value=''):
     # return original value if it's not a dict
     if not isinstance(lang_dict, dict):
         return lang_dict
 
-    # if this is not a proper lang_dict ('de', 'fr', etc. keys), return original value
+    """
+    if this is not a proper lang_dict ('de', 'fr', etc. keys),
+    return original value
+    """
     if not all(k in lang_dict for k in get_langs()):
         return lang_dict
 
@@ -95,56 +117,63 @@ def get_localized_value(lang_dict, desired_lang_code=None, default_value=''):
     except KeyError:
         pass
 
+    return _lang_fallback(lang_dict, default_value)
+
+
+def _lang_fallback(lang_dict, default_value):
     # loop over languages in order of their priority for fallback
     for lang_code in get_langs():
         try:
-            if isinstance(lang_dict[lang_code], basestring) and lang_dict[lang_code]:
+            if (isinstance(lang_dict[lang_code], basestring) and
+                    lang_dict[lang_code]):
                 return lang_dict[lang_code]
         except (KeyError, IndexError, ValueError):
             continue
     return default_value
 
+
 def get_frequency_name(identifier):
     frequencies = {
-      'http://purl.org/cld/freq/completelyIrregular': _('Irregular'),
-      'http://purl.org/cld/freq/continuous': _('Continuous'),
-      'http://purl.org/cld/freq/daily': _('Daily'),
-      'http://purl.org/cld/freq/threeTimesAWeek': _('Three times a week'),
-      'http://purl.org/cld/freq/semiweekly': _('Semi weekly'),
-      'http://purl.org/cld/freq/weekly': _('Weekly'),
-      'http://purl.org/cld/freq/threeTimesAMonth': _('Three times a month'),
-      'http://purl.org/cld/freq/biweekly': _('Biweekly'),
-      'http://purl.org/cld/freq/semimonthly': _('Semimonthly'),
-      'http://purl.org/cld/freq/monthly': _('Monthly'),
-      'http://purl.org/cld/freq/bimonthly': _('Bimonthly'),
-      'http://purl.org/cld/freq/quarterly': _('Quarterly'),
-      'http://purl.org/cld/freq/threeTimesAYear': _('Three times a year'),
-      'http://purl.org/cld/freq/semiannual': _('Semi Annual'),
-      'http://purl.org/cld/freq/annual': _('Annual'),
-      'http://purl.org/cld/freq/biennial': _('Biennial'),
-      'http://purl.org/cld/freq/triennial': _('Triennial'),
+      'http://purl.org/cld/freq/completelyIrregular': _('Irregular'),  # noqa
+      'http://purl.org/cld/freq/continuous': _('Continuous'),  # noqa
+      'http://purl.org/cld/freq/daily': _('Daily'),  # noqa
+      'http://purl.org/cld/freq/threeTimesAWeek': _('Three times a week'),  # noqa
+      'http://purl.org/cld/freq/semiweekly': _('Semi weekly'),  # noqa
+      'http://purl.org/cld/freq/weekly': _('Weekly'),  # noqa
+      'http://purl.org/cld/freq/threeTimesAMonth': _('Three times a month'),  # noqa
+      'http://purl.org/cld/freq/biweekly': _('Biweekly'),  # noqa
+      'http://purl.org/cld/freq/semimonthly': _('Semimonthly'),  # noqa
+      'http://purl.org/cld/freq/monthly': _('Monthly'),  # noqa
+      'http://purl.org/cld/freq/bimonthly': _('Bimonthly'),  # noqa
+      'http://purl.org/cld/freq/quarterly': _('Quarterly'),  # noqa
+      'http://purl.org/cld/freq/threeTimesAYear': _('Three times a year'),  # noqa
+      'http://purl.org/cld/freq/semiannual': _('Semi Annual'),  # noqa
+      'http://purl.org/cld/freq/annual': _('Annual'),  # noqa
+      'http://purl.org/cld/freq/biennial': _('Biennial'),  # noqa
+      'http://purl.org/cld/freq/triennial': _('Triennial'),  # noqa
     }
     try:
         return frequencies[identifier]
     except KeyError:
         return identifier
 
+
 def get_terms_of_use_icon(terms_of_use):
     term_to_image_mapping = {
-        'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired': {
+        'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired': {  # noqa
             'title': _('Open data'),
             'icon': 'terms_open',
         },
-        'NonCommercialAllowed-CommercialAllowed-ReferenceRequired': {
+        'NonCommercialAllowed-CommercialAllowed-ReferenceRequired': {  # noqa
             'title': _('Reference required'),
             'icon': 'terms_by',
         },
-        'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired': {
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired': {  # noqa
             'title': _('Commercial use with permission allowed'),
             'icon': 'terms_ask',
         },
-        'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired': {
-            'title': _('Reference required / Commercial use with permission allowed'),
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired': {  # noqa
+            'title': _('Reference required / Commercial use with permission allowed'),  # noqa
             'icon': 'terms_by-ask',
         },
         'ClosedData': {
@@ -155,31 +184,38 @@ def get_terms_of_use_icon(terms_of_use):
     term_id = simplify_terms_of_use(terms_of_use)
     return term_to_image_mapping.get(term_id, None)
 
+
 def simplify_terms_of_use(term_id):
     terms = [
-      'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired',
-      'NonCommercialAllowed-CommercialAllowed-ReferenceRequired',
-      'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired',
-      'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired',
+        'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired',
+        'NonCommercialAllowed-CommercialAllowed-ReferenceRequired',
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired',
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired',
     ]
 
     if term_id in terms:
         return term_id
     return 'ClosedData'
 
+
 def get_dataset_terms_of_use(pkg):
     rights = logic.get_action('ogdch_dataset_terms_of_use')({}, {'id': pkg})
     return rights['dataset_rights']
 
+
 def get_dataset_by_identifier(identifier):
     try:
-        return logic.get_action('ogdch_dataset_by_identifier')({'for_view': True}, {'identifier': identifier})
+        return logic.get_action('ogdch_dataset_by_identifier')(
+            {'for_view': True},
+            {'identifier': identifier}
+        )
     except logic.NotFound:
         return None
 
+
 def get_readable_file_size(num, suffix='B'):
     try:
-        for unit in ['','K','M','G','T','P','E','Z']:
+        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
             num = float(num)
             if abs(num) < 1024.0:
                 return "%3.1f%s%s" % (num, unit, suffix)
@@ -187,6 +223,7 @@ def get_readable_file_size(num, suffix='B'):
         return "%.1f%s%s" % (num, 'Y', suffix)
     except ValueError:
         return False
+
 
 def parse_json(value, default_value=None):
     try:
@@ -196,9 +233,14 @@ def parse_json(value, default_value=None):
             return default_value
         return value
 
+
 def get_content_headers(url):
     response = requests.head(url)
     return response
 
+
 def get_piwik_config():
-    return { 'url': pylons.config.get('piwik.url', False), 'site_id': pylons.config.get('piwik.site_id', False)}
+    return {
+        'url': pylons.config.get('piwik.url', False),
+        'site_id': pylons.config.get('piwik.site_id', False)
+    }

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from ckan.plugins.toolkit import get_or_bust, side_effect_free, ObjectNotFound
+from ckan.plugins.toolkit import get_or_bust, side_effect_free
 from ckan.logic import NotFound
 import ckan.plugins.toolkit as tk
 from ckanext.switzerland.helpers import get_content_headers
@@ -13,7 +13,7 @@ def ogdch_dataset_count(context, data_dict):
     '''
     Return the total number of datasets and the number of dataset per group.
     '''
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     req_context = {'user': user['name']}
 
     # group_list contains the number of datasets in the 'packages' field
@@ -22,14 +22,17 @@ def ogdch_dataset_count(context, data_dict):
     for group in groups:
         group_count[group['name']] = group['package_count']
 
-
     # get the total number of dataset from package_search
-    search_result = tk.get_action('package_search')(req_context, {'rows': 0, 'fq': '+dataset_type:dataset'})
+    search_result = tk.get_action('package_search')(
+        req_context,
+        {'rows': 0, 'fq': '+dataset_type:dataset'}
+    )
 
     return {
         'total_count': search_result['count'],
         'groups': group_count,
     }
+
 
 @side_effect_free
 def ogdch_content_headers(context, data_dict):
@@ -40,27 +43,28 @@ def ogdch_content_headers(context, data_dict):
     response = get_content_headers(url)
     return {
         'status_code': response.status_code,
-        'content-length': response.headers.get('content-length',''),
+        'content-length': response.headers.get('content-length', ''),
         'content-type': response.headers.get('content-type', ''),
     }
+
 
 @side_effect_free
 def ogdch_dataset_terms_of_use(context, data_dict):
     '''
     Returns the terms of use for the requested dataset.
 
-    By definition the terms of use of a dataset corresponds 
+    By definition the terms of use of a dataset corresponds
     to the least open rights statement of all distributions of
     the dataset
     '''
     terms = [
-      'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired',
-      'NonCommercialAllowed-CommercialAllowed-ReferenceRequired',
-      'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired',
-      'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired',
-      'ClosedData',
+        'NonCommercialAllowed-CommercialAllowed-ReferenceNotRequired',
+        'NonCommercialAllowed-CommercialAllowed-ReferenceRequired',
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceNotRequired',
+        'NonCommercialAllowed-CommercialWithPermission-ReferenceRequired',
+        'ClosedData',
     ]
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     req_context = {'user': user['name']}
     pkg_id = get_or_bust(data_dict, 'id')
     pkg = tk.get_action('package_show')(req_context, {'id': pkg_id})
@@ -83,14 +87,15 @@ def ogdch_dataset_terms_of_use(context, data_dict):
         'dataset_rights': least_open
     }
 
+
 @side_effect_free
 def ogdch_dataset_by_identifier(context, data_dict):
-    user = tk.get_action('get_site_user')({'ignore_auth': True},{})
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     context.update({'user': user['name']})
     identifier = get_or_bust(data_dict, 'identifier')
 
     param = 'identifier:%s' % identifier
-    result = tk.get_action('package_search')(context, {'fq': param })
+    result = tk.get_action('package_search')(context, {'fq': param})
     try:
         return result['results'][0]
     except (KeyError, IndexError, TypeError):

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -1,5 +1,19 @@
 # coding=UTF-8
 
+from ckanext.switzerland import validators as v
+from ckanext.switzerland.logic import (
+    ogdch_dataset_count, ogdch_dataset_terms_of_use,
+    ogdch_dataset_by_identifier, ogdch_content_headers
+)
+from ckanext.switzerland.helpers import (
+    get_dataset_count, get_group_count, get_app_count,
+    get_org_count, get_tweet_count, get_localized_value,
+    get_localized_org, localize_json_title, get_langs,
+    get_frequency_name, get_terms_of_use_icon, get_dataset_terms_of_use,
+    get_dataset_by_identifier, get_readable_file_size,
+    simplify_terms_of_use, parse_json, get_piwik_config
+)
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.helpers as h
@@ -7,26 +21,11 @@ from ckan.lib.munge import munge_title_to_name
 import pylons
 import json
 import re
-import pprint
 import collections
-from webhelpers.html import escape, HTML, literal, url_escape
+from webhelpers.html import HTML
 from webhelpers import paginate
 import logging
 log = logging.getLogger(__name__)
-
-from ckanext.switzerland import validators
-from ckanext.switzerland.logic import (
-   ogdch_dataset_count, ogdch_dataset_terms_of_use,
-   ogdch_dataset_by_identifier, ogdch_content_headers
-)
-from ckanext.switzerland.helpers import (
-   get_dataset_count, get_group_count, get_app_count,
-   get_org_count, get_tweet_count, get_localized_value,
-   get_localized_org, localize_json_title, get_langs,
-   get_frequency_name, get_terms_of_use_icon, get_dataset_terms_of_use,
-   get_dataset_by_identifier, get_readable_file_size,
-   simplify_terms_of_use, parse_json, get_piwik_config
-)
 
 
 class OgdchPlugin(plugins.SingletonPlugin):
@@ -47,14 +46,14 @@ class OgdchPlugin(plugins.SingletonPlugin):
 
     def get_validators(self):
         return {
-            'multiple_text': validators.multiple_text,
-            'multiple_text_output': validators.multiple_text_output,
-            'multilingual_text_output': validators.multilingual_text_output,
-            'list_of_dicts': validators.list_of_dicts,
-            'timestamp_to_datetime': validators.timestamp_to_datetime,
-            'ogdch_multiple_choice': validators.ogdch_multiple_choice,
-            'ogdch_unique_identifier': validators.ogdch_unique_identifier,
-            'temporals_to_datetime_output': validators.temporals_to_datetime_output,
+            'multiple_text': v.multiple_text,
+            'multiple_text_output': v.multiple_text_output,
+            'multilingual_text_output': v.multilingual_text_output,
+            'list_of_dicts': v.list_of_dicts,
+            'timestamp_to_datetime': v.timestamp_to_datetime,
+            'ogdch_multiple_choice': v.ogdch_multiple_choice,
+            'ogdch_unique_identifier': v.ogdch_unique_identifier,
+            'temporals_to_datetime_output': v.temporals_to_datetime_output,
             'parse_json': parse_json,
         }
 
@@ -80,7 +79,8 @@ class OgdchPlugin(plugins.SingletonPlugin):
         facets_dict['res_rights'] = plugins.toolkit._('Terms of use')
         facets_dict['res_format'] = plugins.toolkit._('Formats')
 
-    def organization_facets(self, facets_dict, organization_type, package_type):
+    def organization_facets(self, facets_dict, organization_type,
+                            package_type):
         lang_code = pylons.request.environ['CKAN_LANG']
         # the IFacets implementation of CKAN 2.4 is broken,
         # clear the dict instead and change the passed in argument
@@ -153,7 +153,10 @@ class OgdchLanguagePlugin(plugins.SingletonPlugin):
         pkg_dict['display_name'] = pkg_dict['title']
         for key, value in pkg_dict.iteritems():
             if not self._ignore_field(key):
-                pkg_dict[key] = self._extract_lang_value(value, desired_lang_code)
+                pkg_dict[key] = self._extract_lang_value(
+                    value,
+                    desired_lang_code
+                )
         return pkg_dict
 
     def _ignore_field(self, key):
@@ -176,9 +179,10 @@ class OgdchOrganizationPlugin(OgdchLanguagePlugin):
     def before_view(self, pkg_dict):
         return super(OgdchOrganizationPlugin, self).before_view(pkg_dict)
 
+
 class OgdchResourcePlugin(OgdchLanguagePlugin):
     plugins.implements(plugins.IResourceController, inherit=True)
-    
+
     # IResourceController
 
     def before_show(self, pkg_dict):
@@ -214,20 +218,34 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
             pkg_dict[key] = self._extract_lang_value(value, desired_lang_code)
 
         # groups
+        pkg_dict = self._group_before_view(pkg_dict, desired_lang_code)
+
+        # organization
+        pkg_dict = self._org_before_view(pkg_dict, desired_lang_code)
+
+        return pkg_dict
+
+    def _group_before_view(self, pkg_dict, desired_lang_code):
         try:
             for element in pkg_dict['groups']:
                 for field in element:
-                    element[field] = self._extract_lang_value(element[field], desired_lang_code)
+                    element[field] = self._extract_lang_value(
+                        element[field],
+                        desired_lang_code
+                    )
         except TypeError:
             pass
+        return pkg_dict
 
-        # organization
+    def _org_before_view(self, pkg_dict, desired_lang_code):
         try:
             for field in pkg_dict['organization']:
-                pkg_dict['organization'][field] = self._extract_lang_value(pkg_dict['organization'][field], desired_lang_code)
+                pkg_dict['organization'][field] = self._extract_lang_value(
+                    pkg_dict['organization'][field],
+                    desired_lang_code
+                )
         except TypeError:
             pass
-
         return pkg_dict
 
     def after_show(self, context, pkg_dict):
@@ -237,7 +255,10 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         # groups
         if pkg_dict['groups'] is not None:
             for group in pkg_dict['groups']:
-                # TODO: somehow the title is messed up here, but the display_name is okay
+                """
+                TODO: somehow the title is messed up here,
+                but the display_name is okay
+                """
                 group['title'] = group['display_name']
                 for field in group:
                     group[field] = parse_json(group[field])
@@ -245,7 +266,9 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         # organization
         if pkg_dict['organization'] is not None:
             for field in pkg_dict['organization']:
-                pkg_dict['organization'][field] = parse_json(pkg_dict['organization'][field])
+                pkg_dict['organization'][field] = parse_json(
+                    pkg_dict['organization'][field]
+                )
 
     def before_index(self, search_data):
         if not self.is_supported_package_type(search_data):
@@ -253,26 +276,37 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
 
         extract_title = LangToString('title')
         validated_dict = json.loads(search_data['validated_data_dict'])
-        
+
         # log.debug(pprint.pformat(validated_dict))
 
-        search_data['res_name'] = [r['title'] for r in validated_dict[u'resources']]
-        search_data['res_format'] = [r['media_type'] for r in validated_dict[u'resources']]
-        search_data['res_rights'] = [simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources']]
+        search_data['res_name'] = [r['title'] for r in validated_dict[u'resources']]  # noqa
+        search_data['res_format'] = [r['media_type'] for r in validated_dict[u'resources']]  # noqa
+        search_data['res_rights'] = [simplify_terms_of_use(r['rights']) for r in validated_dict[u'resources']]  # noqa
         search_data['title_string'] = extract_title(validated_dict)
-        search_data['description'] = LangToString('description')(validated_dict)
+        search_data['description'] = LangToString('description')(validated_dict)  # noqa
 
         try:
             # index language-specific values (or it's fallback)
             text_field_items = {}
             for lang_code in get_langs():
-                search_data['title_' + lang_code] = get_localized_value(validated_dict['title'], lang_code)
-                search_data['title_string_' + lang_code] = munge_title_to_name(get_localized_value(validated_dict['title'], lang_code))
-                search_data['description_' + lang_code] = get_localized_value(validated_dict['description'], lang_code)
-                search_data['keywords_' + lang_code] = get_localized_value(validated_dict['keywords'], lang_code)
+                search_data['title_' + lang_code] = get_localized_value(
+                    validated_dict['title'],
+                    lang_code
+                )
+                search_data['title_string_' + lang_code] = munge_title_to_name(
+                    get_localized_value(validated_dict['title'], lang_code)
+                )
+                search_data['description_' + lang_code] = get_localized_value(
+                    validated_dict['description'],
+                    lang_code
+                )
+                search_data['keywords_' + lang_code] = get_localized_value(
+                    validated_dict['keywords'],
+                    lang_code
+                )
 
-                text_field_items['text_' + lang_code] = [get_localized_value(validated_dict['description'], lang_code)]
-                text_field_items['text_' + lang_code].extend(search_data['keywords_' + lang_code])
+                text_field_items['text_' + lang_code] = [get_localized_value(validated_dict['description'], lang_code)]  # noqa
+                text_field_items['text_' + lang_code].extend(search_data['keywords_' + lang_code])  # noqa
 
             # flatten values for text_* fields
             for key, value in text_field_items.iteritems():
@@ -283,7 +317,7 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
 
         # log.debug(pprint.pformat(search_data))
         return search_data
-   
+
     # borrowed from ckanext-multilingual (core extension)
     def before_search(self, search_params):
         """
@@ -307,7 +341,7 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
                 raise
 
         # fallback to default locale if locale not in suported langs
-        if not current_lang in lang_set:
+        if current_lang not in lang_set:
             current_lang = pylons.config.get('ckan.locale_default', 'en')
         # treat current lang differenly so remove from set
         lang_set.remove(current_lang)
@@ -319,7 +353,7 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
             query_fields += ' title_%s^2 text_%s' % (lang, lang)
 
         search_params['qf'] = query_fields
-        
+
         '''
         Unless the query is already being filtered by any type
         (either positively, or negatively), reduce to only display
@@ -347,6 +381,7 @@ class LangToString(object):
             % (lang['de'], lang['fr'], lang['it'], lang['en'])
         )
 
+
 # Monkeypatch to style CKAN pagination
 class OGDPage(paginate.Page):
     # Curry the pager method of the webhelpers.paginate.Page class, so we have
@@ -354,7 +389,7 @@ class OGDPage(paginate.Page):
 
     def pager(self, *args, **kwargs):
         kwargs.update(
-            format=u"<ul class='pagination'>$link_previous ~2~ $link_next</ul>",
+            format=u"<ul class='pagination'>$link_previous ~2~ $link_next</ul>",  # noqa
             symbol_previous=u'«', symbol_next=u'»',
             curpage_attr={'class': 'active'}, link_attr={}
         )

--- a/ckanext/switzerland/validators.py
+++ b/ckanext/switzerland/validators.py
@@ -4,10 +4,10 @@ from ckanext.scheming.validation import scheming_validator
 from ckanext.switzerland.helpers import parse_json
 from ckan.logic import NotFound, get_action
 import json
-import pprint
 import datetime
 import logging
 log = logging.getLogger(__name__)
+
 
 @scheming_validator
 def multiple_text(field, schema):
@@ -30,7 +30,9 @@ def multiple_text(field, schema):
             if isinstance(value, basestring):
                 value = [value]
             elif not isinstance(value, list):
-                errors[key].append(_('Expecting list of strings, got "%s"') % str(value) )
+                errors[key].append(
+                    _('Expecting list of strings, got "%s"') % str(value)
+                )
                 return
         else:
             value = []
@@ -39,6 +41,7 @@ def multiple_text(field, schema):
             data[key] = json.dumps(value)
 
     return validator
+
 
 def multilingual_text_output(value):
     """
@@ -49,6 +52,7 @@ def multilingual_text_output(value):
         return value
     return parse_json(value)
 
+
 def timestamp_to_datetime(value):
     """
     Returns a datetime for a given timestamp
@@ -57,6 +61,7 @@ def timestamp_to_datetime(value):
         return datetime.datetime.fromtimestamp(int(value)).isoformat()
     except ValueError:
         return False
+
 
 def temporals_to_datetime_output(value):
     """
@@ -67,9 +72,13 @@ def temporals_to_datetime_output(value):
 
     for temporal in value:
         for key in temporal:
-            temporal[key] = timestamp_to_datetime(temporal[key]) if temporal[key] else None
+            if temporal[key]:
+                temporal[key] = timestamp_to_datetime(temporal[key])
+            else:
+                temporal[key] = None
     return value
-    
+
+
 @scheming_validator
 def list_of_dicts(field, schema):
     def validator(key, data, errors, context):
@@ -78,14 +87,16 @@ def list_of_dicts(field, schema):
         if errors[key]:
             return
 
-        try: 
+        try:
             data_dict = df.unflatten(data[('__junk',)])
             value = data_dict[key[0]]
             if value is not missing:
                 if isinstance(value, basestring):
                     value = [value]
                 elif not isinstance(value, list):
-                    errors[key].append(_('Expecting list of strings, got "%s"') % str(value) )
+                    errors[key].append(
+                        _('Expecting list of strings, got "%s"') % str(value)
+                    )
                     return
             else:
                 value = []
@@ -101,11 +112,13 @@ def list_of_dicts(field, schema):
 
     return validator
 
+
 def multiple_text_output(value):
     """
     Return stored json representation as a list
     """
     return parse_json(value, default_value=[value])
+
 
 @scheming_validator
 def ogdch_multiple_choice(field, schema):
@@ -130,7 +143,9 @@ def ogdch_multiple_choice(field, schema):
             if isinstance(value, basestring):
                 value = [value]
             elif not isinstance(value, list):
-                errors[key].append(_('Expecting list of strings, got "%s"') % str(value))
+                errors[key].append(
+                    _('Expecting list of strings, got "%s"') % str(value)
+                )
                 return
         else:
             value = []
@@ -144,9 +159,11 @@ def ogdch_multiple_choice(field, schema):
 
         if not errors[key]:
             data[key] = json.dumps([
-                c['value'] for c in field['choices'] if c['value'] in selected])
+                c['value'] for c in field['choices'] if c['value'] in selected
+            ])
 
     return validator
+
 
 @scheming_validator
 def ogdch_unique_identifier(field, schema):
@@ -154,10 +171,14 @@ def ogdch_unique_identifier(field, schema):
         id = data.get(key[:-1] + ('id',))
         identifier = data.get(key[:-1] + ('identifier',))
         try:
-            result = get_action('ogdch_dataset_by_identifier')({},
-                      {'identifier': identifier})
+            result = get_action('ogdch_dataset_by_identifier')(
+                {},
+                {'identifier': identifier}
+            )
             if id != result['id']:
-                raise df.Invalid(_('Identifier is already in use, it must be unique.'))
+                raise df.Invalid(
+                    _('Identifier is already in use, it must be unique.')
+                )
         except NotFound:
             pass
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+# This file lists the dependencies of this extension.
+# Install with a command like: pip install -r requirements.txt 
+flake8==2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = ./ckanext/switzerland/tests/*,setup.py
+max-complexity = 10


### PR DESCRIPTION
The CKAN behaviour is to only display dataset on the dataset search
page, but e.g. the organization pages displays all packages that belong
to an organization (including harvest sources).

This change makes sure that the filter for packages with the type
dataset is always applied if no such filter already exists.

This means that a plugin that implements it's own dataset type should
not be affected, if it is implemented correctly.